### PR TITLE
Update build_numpy_pdf.yml to do pixi init before installs

### DIFF
--- a/.github/workflows/build_numpy_pdf.yml
+++ b/.github/workflows/build_numpy_pdf.yml
@@ -38,6 +38,7 @@ jobs:
     - run: pixi run test
     - name: Install dependencies
       run: |
+        pixi init
         pixi add python=3.11 tectonic doxygen
         pixi add --pypi $(cat numpy/requirements/build_requirements.txt | sed '/^#/d'| sed -r '/^\s*$/d' | sed 's/\(.*\)/"\1"/g')
         pixi add --pypi $(cat numpy/requirements/doc_requirements.txt | sed '/^#/d'| sed -r '/^\s*$/d' | sed 's/\(.*\)/"\1"/g')


### PR DESCRIPTION
I think this should work?
https://prefix.dev/docs/pixi/cli#init